### PR TITLE
✨ Add ansible playbook for docker daemon

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+interpreter_python=/usr/bin/python3
+inventory=hosts.yml
+
+

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,0 +1,27 @@
+---
+# Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
+docker_edition: 'ce'
+docker_package: "docker-{{ docker_edition }}"
+docker_package_state: present
+
+# Service options.
+docker_service_state: started
+docker_service_enabled: true
+docker_restart_handler_state: restarted
+
+# Docker Compose options.
+docker_install_compose: true
+docker_compose_version: "1.29.1"
+docker_compose_url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
+docker_compose_path: /usr/local/bin/docker-compose
+
+# Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
+docker_repo_url: https://download.docker.com/linux
+docker_apt_release_channel: stable
+docker_apt_arch: amd64
+docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_ignore_key_error: true
+docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+
+# A list of users who will be added to the docker group.
+docker_users: [ 'sial' ]

--- a/group_vars/all
+++ b/group_vars/all
@@ -24,4 +24,4 @@ docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 
 # A list of users who will be added to the docker group.
-docker_users: [ 'sial' ]
+docker_users: [ 'sial', 'github' ]

--- a/hosts.yml
+++ b/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    malachor.mcru.pink:
+      ansible_host: malachor.mcru.pink
+

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,16 @@
+---
+# This playbook deploys docker on all the hosts
+
+- name: configure and deploy docker daemon
+  hosts: all
+  remote_user: github
+  become: true
+
+  vars:
+    pip_install_packages:
+      - name: docker
+
+  roles:
+    - geerlingguy.pip
+    - geerlingguy.docker
+


### PR DESCRIPTION
Used ansible-galaxy role which installs docker daemon, docker python client and docker-compose.
Closes #4 